### PR TITLE
Release 1.2.11 — unauthenticated media enumeration + Jetpack widget gate

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -10,8 +10,9 @@ jQuery( document ).ready(function() {// jscs:ignore validateLineBreaks
             type: 'POST',
             data: ajaxData,
             url: shapelyCompanion.ajaxurl,
+            dataType: 'json',
             success: function( data ) {
-                if ( 'succes' === data ) {
+                if ( data && ( true === data.success || ( data.data && true === data.data.status ) || 'succes' === data ) ) {
                     currentButton.removeClass( 'disabled' );
                     currentButton.next( '.spinner' ).removeClass( 'is-active' );
                     currentButton.parent().parent().find( '.updated-message' ).show();
@@ -61,7 +62,8 @@ jQuery(function( $ ) {
             var selector = $( '.shapely-media-control' ).find( mediaControl.selector );
             var data = {
                 action: 'shapely_get_attachment_media',
-                attachment_id: id
+                attachment_id: id,
+                nonce: shapelyCompanion.nonce
             };
 
             if ( ! selector.length ) {

--- a/assets/js/widget.js
+++ b/assets/js/widget.js
@@ -29,7 +29,7 @@
     function shapelySort() {
       $( '.client-sortable' ).sortable( {
         handle: '.logo_heading'
-      } ).bind( 'sortupdate', function() {
+      } ).on( 'sortupdate', function() {
         let index = 0, img;
         let attrname = $( this ).find( 'input:first' ).attr( 'name' );
         let attrbase = attrname.substring( 0, attrname.indexOf( '][' ) + 1 );

--- a/inc/shapely-demo-content.php
+++ b/inc/shapely-demo-content.php
@@ -63,6 +63,57 @@ function shapely_companion_add_default_widgets() {
 	update_option( 'sidebars_widgets', $sidebars_widgets );
 }
 
+/**
+ * Find an existing page by title, or create it.
+ *
+ * The importer previously called wp_insert_post() unconditionally, so pressing
+ * "Import Demo Content" a second time produced duplicate "Front Page" and
+ * "Blog" pages (front-page-2, blog-2) and a doubled homepage. get_page_by_title()
+ * is deliberately not used: it was deprecated in WordPress 6.2.
+ *
+ * @param string $title   Page title.
+ * @param string $content Content used only when the page is created.
+ *
+ * @return int Page ID.
+ */
+function shapely_companion_get_or_create_page( $title, $content ) {
+	$existing = new WP_Query(
+		array(
+			'post_type'              => 'page',
+			'title'                  => $title,
+			'post_status'            => array( 'publish', 'draft', 'pending', 'private' ),
+			'posts_per_page'         => 1,
+			'no_found_rows'          => true,
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'orderby'                => 'ID',
+			'order'                  => 'ASC',
+		)
+	);
+
+	if ( ! empty( $existing->posts ) ) {
+		$id = (int) $existing->posts[0]->ID;
+		if ( 'publish' !== get_post_status( $id ) ) {
+			wp_update_post(
+				array(
+					'ID'          => $id,
+					'post_status' => 'publish',
+				)
+			);
+		}
+		return $id;
+	}
+
+	return (int) wp_insert_post(
+		array(
+			'post_title'   => $title,
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+			'post_content' => $content,
+		)
+	);
+}
+
 add_action( 'wp_ajax_shapely_companion_import_content', 'shapely_companion_import_content' );
 
 function shapely_companion_import_content() {
@@ -101,27 +152,16 @@ function shapely_companion_import_content() {
 			$frontpage_title = __( 'Front Page', 'shapely-companion' );
 			$blog_title      = __( 'Blog', 'shapely-companion' );
 
-			// Create front page
-			$frontpage_id = wp_insert_post(
-				array(
-					'post_title'    => $frontpage_title,
-					'post_status'   => 'publish',
-					'post_type'     => 'page',
-					'post_content'  => 'This is your front page. Click edit to change this text.',
-				)
+			// Reuse the existing front page if the importer has already run.
+			$frontpage_id = shapely_companion_get_or_create_page(
+				$frontpage_title,
+				'This is your front page. Click edit to change this text.'
 			);
-			$log[] = 'Front page created with ID: ' . $frontpage_id;
+			$log[] = 'Front page ID: ' . $frontpage_id;
 
-			// Create blog page
-			$blog_id = wp_insert_post(
-				array(
-					'post_title'    => $blog_title,
-					'post_status'   => 'publish',
-					'post_type'     => 'page',
-					'post_content'  => 'This is your blog page.',
-				)
-			);
-			$log[] = 'Blog page created with ID: ' . $blog_id;
+			// Reuse the existing blog page if the importer has already run.
+			$blog_id = shapely_companion_get_or_create_page( $blog_title, 'This is your blog page.' );
+			$log[] = 'Blog page ID: ' . $blog_id;
 
 			if ( -1 != $frontpage_id ) {
 				update_post_meta( $frontpage_id, '_wp_page_template', 'page-templates/template-home.php' );

--- a/inc/shapely-helper.php
+++ b/inc/shapely-helper.php
@@ -29,11 +29,38 @@ function shapely_author_social_links( $contactmethods ) {
 }
 add_filter( 'user_contactmethods', 'shapely_author_social_links', 10, 1 );
 
+/**
+ * Authorise an attachment-resolution AJAX request.
+ *
+ * These endpoints back the media picker on the widget/customizer admin screens,
+ * which only a logged-in editor ever reaches. They were also registered for
+ * wp_ajax_nopriv_*, with no nonce and no capability check, so any logged-out
+ * visitor could POST an attachment ID and receive its URL -- enough to walk the
+ * ID space and enumerate every attachment on the site, including media attached
+ * to drafts and private posts.
+ *
+ * @return int Validated attachment ID, or 0.
+ */
+function shapely_validate_attachment_request() {
+	check_ajax_referer( 'welcome_nonce', 'nonce' );
+
+	if ( ! current_user_can( 'upload_files' ) ) {
+		wp_die( '', '', array( 'response' => 403 ) );
+	}
+
+	$id = isset( $_POST['attachment_id'] ) ? absint( wp_unslash( $_POST['attachment_id'] ) ) : 0;
+
+	if ( $id > 0 && 'attachment' !== get_post_type( $id ) ) {
+		return 0;
+	}
+
+	return $id;
+}
+
 add_action( 'wp_ajax_shapely_get_attachment_image', 'shapely_get_attachment_image' );
-add_action( 'wp_ajax_nopriv_shapely_get_attachment_image', 'shapely_get_attachment_image' );
 
 function shapely_get_attachment_image() {
-	$id  = isset( $_POST['attachment_id'] ) ? intval( $_POST['attachment_id'] ) : 0;
+	$id  = shapely_validate_attachment_request();
 	$src = wp_get_attachment_image_src( $id, 'full', false );
 
 	if ( ! empty( $src[0] ) ) {
@@ -44,10 +71,9 @@ function shapely_get_attachment_image() {
 }
 
 add_action( 'wp_ajax_shapely_get_attachment_media', 'shapely_get_attachment_media' );
-add_action( 'wp_ajax_nopriv_shapely_get_attachment_media', 'shapely_get_attachment_media' );
 
 function shapely_get_attachment_media() {
-	$id  = isset( $_POST['attachment_id'] ) ? intval( $_POST['attachment_id'] ) : 0;
+	$id  = shapely_validate_attachment_request();
 	$src = wp_get_attachment_image_src( $id, 'full', false );
 
 	if ( ! empty( $src[0] ) ) {

--- a/inc/shapely-widgets.php
+++ b/inc/shapely-widgets.php
@@ -42,12 +42,26 @@ function shapely_companion_widgets_init() {
 	register_widget( 'Shapely_Page_Title' );
 	register_widget( 'Shapely_Page_Content' );
 
-	if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'custom-content-types' ) ) {
-		if ( get_option( 'jetpack_portfolio' ) ) {
-			register_widget( 'Shapely_Home_Portfolio' );
-		}
-		if ( get_option( 'jetpack_testimonial' ) ) {
-			register_widget( 'Shapely_Home_Testimonials' );
-		}
+	/*
+	 * Gate on the post type rather than Jetpack's legacy module flag. Jetpack 13+
+	 * registers the Portfolio/Testimonial CPTs without marking
+	 * 'custom-content-types' active in jetpack_active_modules, so
+	 * Jetpack::is_module_active() returns false even when the post types are
+	 * registered and the site owner has enabled them -- which silently dropped
+	 * both widgets, and with them the Projects and Testimonials sections of the
+	 * demo homepage.
+	 *
+	 * Both signals are checked: wp_widgets_init() runs on init priority 1 while
+	 * Jetpack registers its CPTs at priority 10, so post_type_exists() is still
+	 * false here on a normal request -- the option covers that -- while
+	 * post_type_exists() covers post types supplied by another plugin or a child
+	 * theme without the Jetpack option being set.
+	 */
+	if ( post_type_exists( 'jetpack-portfolio' ) || get_option( 'jetpack_portfolio' ) ) {
+		register_widget( 'Shapely_Home_Portfolio' );
+	}
+
+	if ( post_type_exists( 'jetpack-testimonial' ) || get_option( 'jetpack_testimonial' ) ) {
+		register_widget( 'Shapely_Home_Testimonials' );
 	}
 }

--- a/inc/widgets/class-shapely-home-call-for-action.php
+++ b/inc/widgets/class-shapely-home-call-for-action.php
@@ -48,7 +48,17 @@ class Shapely_Home_Call_For_Action extends WP_Widget {
 									<h3 class="cfa-text"><?php echo wp_kses_post( $instance['title'] ); ?></h3>
 								</div>
 								<div class="col-sm-3">
-									<a href="<?php echo esc_url_raw( $instance['button_link'] ); ?>" class="mb0 btn btn-lg btn-filled cfa-button"><?php echo esc_html( $instance['button'] ); ?></a>
+									<?php
+									/*
+									 * Only emit the button when it has a label; rendering it
+									 * unconditionally produced <a href=""></a> -- an empty link
+									 * with no accessible name. esc_url() (not esc_url_raw()) is
+									 * the output escaper: esc_url_raw leaves "&" unencoded.
+									 */
+									if ( '' !== trim( (string) $instance['button'] ) ) :
+										?>
+										<a href="<?php echo esc_url( $instance['button_link'] ); ?>" class="mb0 btn btn-lg btn-filled cfa-button"><?php echo esc_html( $instance['button'] ); ?></a>
+									<?php endif; ?>
 								</div>
 							</div>
 						</div>

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,9 @@
 Contributors: colorlibplugins, silkalns
 Tags: woocommerce, widgets, demo, companion, one page
 Requires at least: 6.4
-Tested up to: 6.8
-Stable tag: 1.2.10
+Requires PHP: 7.4
+Tested up to: 7.0
+Stable tag: 1.2.11
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +52,16 @@ Currently it works only with Shapely theme.
 You can still use Shapely theme without this plugin but you won't be able to import demo content and use theme specific widgets that you see on front page of theme demo.
 
 == Changelog ==
+
+= 1.2.11 =
+* Security: the shapely_get_attachment_image and shapely_get_attachment_media AJAX actions were also registered for logged-out visitors (wp_ajax_nopriv_) with no nonce and no capability check, letting anyone resolve an arbitrary attachment ID to its URL and enumerate media attached to drafts and private posts. Both now require an authenticated user with the upload_files capability and a valid nonce.
+* Fixed the Portfolio and Testimonials widgets silently disappearing on Jetpack 13 and newer. Registration was gated on Jetpack::is_module_active( 'custom-content-types' ), which now returns false even when the post types are registered and enabled, so both sections vanished from the demo homepage.
+* Import Demo Content is now idempotent: it reuses the existing Front Page and Blog pages instead of creating duplicate front-page-2 / blog-2 pages each time it is run.
+* Replaced the deprecated get_page_by_title() (deprecated in WordPress 6.2) in the demo importer.
+* Fixed the Clients widget logo re-ordering breaking under jQuery 4, which removes jQuery.fn.bind().
+* Fixed the Call for Action widget rendering an empty <a href=""></a> when no button was configured, and using esc_url_raw() for HTML output, which left ampersands unencoded in links with query strings.
+* Committed the admin.js AJAX response handling that shipped in 1.2.10 but was never pushed to the repository.
+* Tested against WordPress 7.0 and PHP 8.5.
 
 = 1.2.10 =
 * Fixed demo content import functionality
@@ -117,3 +128,8 @@ You can still use Shapely theme without this plugin but you won't be able to imp
 
 = 1.0.0 =
 * Initial release.
+
+== Upgrade Notice ==
+
+= 1.2.11 =
+Security release. Two AJAX endpoints were reachable by logged-out visitors and could be used to enumerate media URLs, including attachments on drafts and private posts. Updating is recommended for all sites.

--- a/shapely-companion.php
+++ b/shapely-companion.php
@@ -3,7 +3,10 @@
  * Plugin Name:       Shapely Companion
  * Plugin URI:        https://colorlib.com/wp/themes/shapely/
  * Description:       Shapely Companion is a companion plugin for Shapely theme.
- * Version:           1.2.10
+ * Version:           1.2.11
+ * Requires at least: 6.4
+ * Tested up to:      7.0
+ * Requires PHP:      7.4
  * Author:            Colorlib
  * Author URI:        https://colorlib.com
  * License:           GPL-2.0+


### PR DESCRIPTION
Verified end to end against a live **WordPress 7.0.2 / PHP 8.5.3 / Jetpack 16.0.1** install, with the Shapely theme active and the plugin's own Import Demo Content flow.

## Security — unauthenticated attachment enumeration

`shapely_get_attachment_image()` and `shapely_get_attachment_media()` were registered for `wp_ajax_nopriv_*` with **no nonce and no capability check**. Any logged-out visitor could POST an `attachment_id` and get that attachment's URL back — enough to walk the ID space and enumerate every attachment on the site, including media attached to drafts and private posts.

Confirmed by resolving the featured image of an **unpublished draft** over an unauthenticated request:

```
POST action=shapely_get_attachment_media&attachment_id=<draft attachment>
→ http://…/wp-content/uploads/2026/08/placeholder.jpg
```

After the fix, the same request returns `HTTP 400`.

**Scope, stated honestly:** WordPress serves uploads with no ACL, so a file was always fetchable by anyone who already knew its URL. What these endpoints added was *discovery*. This is information disclosure, not privilege escalation. It only applies when the Shapely theme is active, since the plugin gates its own bootstrap on that — which is its entire audience.

Both endpoints now require an authenticated user with `upload_files` plus a valid nonce, and reject IDs that aren't attachments. A nonce was already being localised as `shapelyCompanion.nonce` but never verified; `admin.js` now sends it. **The media picker still works** — verified logged in, with a valid nonce, an invalid nonce, and a non-attachment ID.

## Portfolio and Testimonials widgets vanished on Jetpack 13+

Registration was gated on `Jetpack::is_module_active( 'custom-content-types' )`. Modern Jetpack registers the Portfolio/Testimonial post types **without** marking that legacy module active, so on Jetpack 16.0.1:

```
Jetpack::is_module_active('custom-content-types')  → false
post_type_exists('jetpack-portfolio')              → true
get_option('jetpack_portfolio')                    → '1'
```

Both widgets silently disappeared, taking the *Our Latest Projects* and *What Our Customers Say* sections of the demo homepage with them.

Now gated on `post_type_exists()` **or** the `jetpack_*` option. Both signals are needed: `wp_widgets_init()` runs on `init` priority 1 while Jetpack registers its CPTs at priority 10, so `post_type_exists()` is still false at registration time — while `post_type_exists()` covers post types supplied by another plugin or a child theme. Verified registering in both directions (2/2 with the CPTs enabled, correctly withheld when disabled).

## Also fixed

- **Import Demo Content is now idempotent.** It called `wp_insert_post()` unconditionally, so every press created another *Front Page* / *Blog* (`front-page-2`, `blog-2`). Now find-or-create — running it twice returns identical IDs.
- Dropped `get_page_by_title()` (deprecated in WordPress 6.2) from the importer.
- `widget.js` used `jQuery.fn.bind()`, **removed in jQuery 4**, which would break logo re-ordering in the Clients widget.
- The Call for Action widget rendered an empty `<a href=""></a>` when no button was configured, and used `esc_url_raw()` — the database escaper — for HTML output, leaving `&` unencoded in links with query strings.
- **Committed the `admin.js` AJAX response handling that shipped in 1.2.10 but was never pushed here.** The repo's changelog already claimed it ("Improved AJAX response handling in admin.js") while the code was missing — the release and the repository had diverged.

## Metadata

Plugin headers gain `Requires at least: 6.4`, `Tested up to: 7.0`, `Requires PHP: 7.4`. `readme.txt` gains the 1.2.11 changelog and an Upgrade Notice for the security fix, ready for SVN.

## Verification

| Check | Result |
|---|---|
| PHP 8.5 lint, 23 files | 0 errors |
| PHPCompatibility `8.5-` | 0 findings |
| Unauthenticated probe, both endpoints | HTTP 400 |
| Authenticated media picker | 4/4 pass |
| Demo import, run twice | identical IDs, no duplicates |
| Demo homepage sections | all 10 widgets placed, every section renders |
| Front-end crawl, 13 templates | 12/13 clean (13th is a deliberate 404) |
| Interactive suite | 36/36, 0 JS errors |
| `WP_DEBUG_LOG` | 0 plugin notices |

Line endings were preserved per file (the PHP is CRLF, the JS is LF), so the diff is 148/37 lines rather than whole-file churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)