### PR TITLE
Hotfix 1.2.12 — fatal error in the Portfolio widget blanks the front page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Install PHPCS + standards
         run: |
+          # phpcodesniffer-composer-installer is a Composer plugin, and Composer
+          # refuses to run plugins that are not explicitly allow-listed. Without
+          # this the require aborts before PHPCS is ever installed.
+          composer global config --no-plugins --no-interaction \
+            allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer global require --no-interaction --no-progress \
             squizlabs/php_codesniffer \
             phpcompatibility/php-compatibility \

--- a/inc/widgets/class-shapely-home-portfolio.php
+++ b/inc/widgets/class-shapely-home-portfolio.php
@@ -37,6 +37,16 @@ class Shapely_Home_Portfolio extends WP_Widget {
 
 		$instance = wp_parse_args( $instance, $this->defaults );
 
+		/*
+		 * Nothing to show without the portfolio post type. WP_Query would still
+		 * return rows straight from the database when the type is unregistered
+		 * -- it does not validate post_type -- so the section would render with
+		 * items whose taxonomy, permalinks and archive links are all broken.
+		 */
+		if ( ! post_type_exists( 'jetpack-portfolio' ) ) {
+			return;
+		}
+
 		echo $args['before_widget']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		/**
@@ -105,6 +115,19 @@ class Shapely_Home_Portfolio extends WP_Widget {
 								'fields' => 'names',
 							);
 							$project_types = wp_get_post_terms( get_the_ID(), 'jetpack-portfolio-type', $args_projects );
+
+							/*
+							 * wp_get_post_terms() returns a WP_Error when the taxonomy is
+							 * not registered -- which happens whenever Jetpack (or whatever
+							 * else supplied the portfolio post type) is deactivated while
+							 * portfolio posts remain in the database. ! empty() is true for
+							 * a WP_Error object, so the implode() below received the object
+							 * and raised a fatal TypeError on PHP 8, truncating the page
+							 * from this point down.
+							 */
+							if ( is_wp_error( $project_types ) ) {
+								$project_types = array();
+							}
 
 							?>
 							<div class="col-md-3 col-sm-6 project fadeIn<?php echo $instance['mansonry'] ? ' masonry-item' : ''; ?>">

--- a/inc/widgets/class-shapely-home-testimonials.php
+++ b/inc/widgets/class-shapely-home-testimonials.php
@@ -36,6 +36,11 @@ class Shapely_Home_Testimonials extends WP_Widget {
 		$limit     = $instance['limit'];
 		$image_src = $instance['image_src'];
 
+		// Same reasoning as the portfolio widget: no post type, nothing to show.
+		if ( ! post_type_exists( 'jetpack-testimonial' ) ) {
+			return;
+		}
+
 		echo $args['before_widget']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shapely-companion",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Build and lint tooling for the Shapely Companion WordPress plugin.",
   "homepage": "https://colorlib.com/wp/themes/shapely/",
   "author": "Colorlib",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, widgets, demo, companion, one page
 Requires at least: 6.4
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 1.2.11
+Stable tag: 1.2.12
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,11 @@ Currently it works only with Shapely theme.
 You can still use Shapely theme without this plugin but you won't be able to import demo content and use theme specific widgets that you see on front page of theme demo.
 
 == Changelog ==
+
+= 1.2.12 =
+* Fixed a fatal error that blanked the lower half of the front page when the Portfolio section was in use and the portfolio post type was not registered -- for example with Jetpack deactivated while portfolio posts remained in the database. wp_get_post_terms() returns a WP_Error in that situation, and because ! empty() is true for an object, implode() received it and raised a TypeError on PHP 8, truncating the page from that point down.
+* The Portfolio and Testimonials widgets now render nothing when their post type is unregistered, instead of querying rows directly out of the database and producing items with broken taxonomy and permalinks.
+* This surfaced in 1.2.11: the widget registration fix in that release meant the Portfolio widget renders on setups where the previous, broken Jetpack check had silently suppressed it -- which had been masking this fault.
 
 = 1.2.11 =
 * Security: the shapely_get_attachment_image and shapely_get_attachment_media AJAX actions were also registered for logged-out visitors (wp_ajax_nopriv_) with no nonce and no capability check, letting anyone resolve an arbitrary attachment ID to its URL and enumerate media attached to drafts and private posts. Both now require an authenticated user with the upload_files capability and a valid nonce.
@@ -130,6 +135,9 @@ You can still use Shapely theme without this plugin but you won't be able to imp
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.2.12 =
+Fixes a fatal error that could blank the lower half of the front page when the Portfolio section is used without the portfolio post type registered. Recommended for anyone running 1.2.11.
 
 = 1.2.11 =
 Security release. Two AJAX endpoints were reachable by logged-out visitors and could be used to enumerate media URLs, including attachments on drafts and private posts. Updating is recommended for all sites.

--- a/shapely-companion.php
+++ b/shapely-companion.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Shapely Companion
  * Plugin URI:        https://colorlib.com/wp/themes/shapely/
  * Description:       Shapely Companion is a companion plugin for Shapely theme.
- * Version:           1.2.11
+ * Version:           1.2.12
  * Requires at least: 6.4
  * Tested up to:      7.0
  * Requires PHP:      7.4


### PR DESCRIPTION
**Regression from 1.2.11. The live demo is currently affected:** <https://colorlibhub.com/shapely/> renders only down to the first project, then stops — no footer, no scripts, so the slider, icons and images below that point never appear.

## Cause

`wp_get_post_terms()` returns a `WP_Error` when `jetpack-portfolio-type` is not a registered taxonomy — which is the case whenever Jetpack (or whatever supplied the portfolio post type) is deactivated while portfolio posts remain in the database.

`! empty()` is **true** for an object, so the existing guard passed and `implode()` got the `WP_Error`:

```
PHP Fatal error: Uncaught TypeError: implode(): Argument #2 ($array) must be
of type ?array, WP_Error given
  in inc/widgets/class-shapely-home-portfolio.php:122
```

Output stops at exactly that line. Everything below — including `wp_footer()` and every enqueued script — is never emitted.

## Why now

This fault is older than 1.2.11, but was unreachable. The widget registration fix in 1.2.11 means the Portfolio widget now registers on setups where the previous, broken `Jetpack::is_module_active()` check had silently suppressed it — and that suppression was masking this.

Confirmed by reverting **only** the gate on a reproduction of the demo's state:

```
old gate (1.2.10)   HTTP 200   widget not rendered   0 fatals
new gate (1.2.11)   HTTP 500                         1 fatal
```

I introduced the exposure. The underlying bug was pre-existing.

## Fix

1. `is_wp_error()` check on the terms result before use.
2. Portfolio **and** Testimonials widgets return early when their post type is not registered. `WP_Query` does not validate `post_type`, so it was returning rows straight from the database and rendering items with broken taxonomy, permalinks and archive links.

## Verified

Reproduced the demo's exact state locally (portfolio posts present, `jetpack_portfolio` option set, taxonomy unregistered) on WordPress 7.0.3 / PHP 8.5:

| State | Before | After |
|---|---|---|
| Post type **absent** | HTTP 500, page truncated, 0 footer scripts | HTTP 200, complete page, section correctly omitted |
| Post type **present** | — | HTTP 200, section renders normally |

Front-end sweep after the fix: all pages complete, `jQuery.fn.flexslider` / `owlCarousel` / `parallax` and `ShapelyAdminObject` all present, 0 PHP notices, 0 JS errors.

Also worth fixing separately: the theme has the same unguarded pattern in `inc/class-shapely-related-posts.php` — not fatal there, but it pushed a `WP_Error` into a `tax_query`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)