### PR TITLE
Stop loading stylesheets out of the theme's directory

### DIFF
--- a/inc/shapely-enqueues.php
+++ b/inc/shapely-enqueues.php
@@ -18,8 +18,29 @@ function shapely_companion_admin_scripts( $hook ) {
 		wp_enqueue_script( 'shapely_cloneya_js', plugins_url( 'assets/js/vendor/jquery-cloneya.min.js', dirname( __FILE__ ) ), array( 'jquery' ) );
 		wp_enqueue_style( 'wp-color-picker' );
 		wp_enqueue_script( 'widget-js', plugins_url( 'assets/js/widget.js', dirname( __FILE__ ) ), array( 'media-upload', 'wp-color-picker' ), '1.0', true );
-		// Add Font Awesome stylesheet
-		wp_enqueue_style( 'font-awesome', get_template_directory_uri() . '/assets/css/font-awesome.min.css' );
+		/*
+		 * Font Awesome for the widget forms' icon fields.
+		 *
+		 * This used to load '/assets/css/font-awesome.min.css' from the theme
+		 * under the generic 'font-awesome' handle. Two problems: Shapely 1.2.21
+		 * removed that file when it moved to Font Awesome 6, so the request
+		 * 404s; and claiming the generic handle can suppress whatever else on
+		 * the page wanted to register it.
+		 *
+		 * Point at the theme's Font Awesome 6 under our own handle, and only if
+		 * it is actually there -- the widgets work without it, the icon
+		 * previews just render as blanks.
+		 */
+		$fa_path = get_template_directory() . '/assets/css/fontawesome6/all.min.css';
+
+		if ( file_exists( $fa_path ) ) {
+			wp_enqueue_style(
+				'shapely-companion-font-awesome',
+				get_template_directory_uri() . '/assets/css/fontawesome6/all.min.css',
+				array(),
+				'6.4.2'
+			);
+		}
 	}
 
 	if ( 'nav-menus.php' == $hook ) {

--- a/inc/widgets/class-shapely-categories.php
+++ b/inc/widgets/class-shapely-categories.php
@@ -10,9 +10,6 @@ class Shapely_Categories extends WP_Widget {
 	private $defaults = array();
 
 	function __construct() {
-		add_action( 'admin_init', array( $this, 'enqueue' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue' ) );
-		add_action( 'customize_preview_init', array( $this, 'enqueue' ) );
 
 		$widget_ops = array(
 			'classname'                   => 'shapely-cats',
@@ -28,11 +25,6 @@ class Shapely_Categories extends WP_Widget {
 		);
 	}
 
-	public function enqueue() {
-		if ( is_admin() && ! is_customize_preview() ) {
-			wp_enqueue_style( 'epsilon-styles', get_template_directory_uri() . '/inc/libraries/epsilon-framework/assets/css/style.css' );
-		}
-	}
 
 	/**
 	 * @param array $args

--- a/inc/widgets/class-shapely-home-contact.php
+++ b/inc/widgets/class-shapely-home-contact.php
@@ -9,9 +9,6 @@ class Shapely_Home_Contact extends WP_Widget {
 	private $defaults = array();
 
 	function __construct() {
-		add_action( 'admin_init', array( $this, 'enqueue' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue' ) );
-		add_action( 'customize_preview_init', array( $this, 'enqueue' ) );
 
 		$widget_ops = array(
 			'classname'                   => 'shapely_home_contact',
@@ -32,13 +29,6 @@ class Shapely_Home_Contact extends WP_Widget {
 		);
 	}
 
-	public function enqueue() {
-
-		if ( is_admin() && ! is_customize_preview() ) {
-			wp_enqueue_style( 'epsilon-styles', get_template_directory_uri() . '/inc/libraries/epsilon-framework/assets/css/style.css' );
-		}
-
-	}
 
 	/**
 	 * @param array $args

--- a/inc/widgets/class-shapely-home-parallax.php
+++ b/inc/widgets/class-shapely-home-parallax.php
@@ -9,9 +9,6 @@ class Shapely_Home_Parallax extends WP_Widget {
 	private $defaults = array();
 
 	function __construct() {
-		add_action( 'admin_init', array( $this, 'enqueue' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue' ) );
-		add_action( 'customize_preview_init', array( $this, 'enqueue' ) );
 
 		$widget_ops = array(
 			'classname'                   => 'shapely_home_parallax',
@@ -33,13 +30,6 @@ class Shapely_Home_Parallax extends WP_Widget {
 		);
 	}
 
-	public function enqueue() {
-
-		if ( is_admin() && ! is_customize_preview() ) {
-			wp_enqueue_style( 'epsilon-styles', get_template_directory_uri() . '/inc/libraries/epsilon-framework/assets/css/style.css' );
-		}
-
-	}
 
 	/**
 	 * @param array $args

--- a/inc/widgets/class-shapely-video.php
+++ b/inc/widgets/class-shapely-video.php
@@ -8,8 +8,6 @@ class Shapely_Video extends WP_Widget {
 	private $defaults = array();
 
 	function __construct() {
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue' ) );
-		add_action( 'customize_preview_init', array( $this, 'enqueue' ) );
 
 		$widget_ops = array(
 			'classname'   => 'shapely_video_widget',
@@ -30,11 +28,6 @@ class Shapely_Video extends WP_Widget {
 		);
 	}
 
-	public function enqueue() {
-		if ( is_admin() && ! is_customize_preview() ) {
-			wp_enqueue_style( 'epsilon-styles', get_template_directory_uri() . '/inc/libraries/epsilon-framework/assets/css/style.css' );
-		}
-	}
 
 	function widget( $args, $instance ) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shapely-companion",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shapely-companion",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shapely-companion",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "Build and lint tooling for the Shapely Companion WordPress plugin.",
   "homepage": "https://colorlib.com/wp/themes/shapely/",
   "author": "Colorlib",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, widgets, demo, companion, one page
 Requires at least: 6.4
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 1.2.12
+Stable tag: 1.2.13
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -52,6 +52,10 @@ Currently it works only with Shapely theme.
 You can still use Shapely theme without this plugin but you won't be able to import demo content and use theme specific widgets that you see on front page of theme demo.
 
 == Changelog ==
+
+= 1.2.13 =
+* Stopped loading two stylesheets out of the Shapely theme's own directory. The plugin was pulling `assets/css/font-awesome.min.css` and the bundled Epsilon framework's stylesheet from wherever the theme happened to be installed -- both of which the theme has since removed, so both 404'd on the widgets and customizer screens. Font Awesome now points at the theme's current copy and only when it is actually present; the Epsilon stylesheet is gone along with the dead hooks that loaded it
+* Font Awesome is no longer registered under the generic `font-awesome` handle, which could suppress another copy already on the page
 
 = 1.2.12 =
 * Fixed a fatal error that blanked the lower half of the front page when the Portfolio section was in use and the portfolio post type was not registered -- for example with Jetpack deactivated while portfolio posts remained in the database. wp_get_post_terms() returns a WP_Error in that situation, and because ! empty() is true for an object, implode() received it and raised a TypeError on PHP 8, truncating the page from that point down.

--- a/shapely-companion.php
+++ b/shapely-companion.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Shapely Companion
  * Plugin URI:        https://colorlib.com/wp/themes/shapely/
  * Description:       Shapely Companion is a companion plugin for Shapely theme.
- * Version:           1.2.12
+ * Version:           1.2.13
  * Requires at least: 6.4
  * Tested up to:      7.0
  * Requires PHP:      7.4


### PR DESCRIPTION
Found while testing Shapely 1.3.0 on a real install.

The plugin loaded two stylesheets from wherever the theme happened to be installed:

| enqueued from the theme | removed by the theme in |
|---|---|
| `assets/css/font-awesome.min.css` | **1.2.21 — already released** |
| `inc/libraries/epsilon-framework/assets/css/style.css` | 1.3.0 |

Both 404 on `widgets.php` and `customize.php`.

**Severity: admin-only and cosmetic.** One is behind `is_admin()`, the other only fires on the widgets and customizer screens. No fatal, nothing visitor-facing. But a plugin reaching into a theme's internal file layout is exactly the coupling that caused the break, so the fix is to stop doing it rather than to chase the paths.

## Changes

- **Font Awesome** now points at the theme's current FA6 copy, under `shapely-companion-font-awesome` rather than the generic `font-awesome` handle — which can suppress another copy already registered on the page — and only when the file is actually present. The widget forms work without it; icon previews just render blank.
- **The Epsilon stylesheet enqueue is removed**, along with the now-empty `enqueue()` methods and the `admin_init` / `customize_controls_enqueue_scripts` / `customize_preview_init` hooks that called them.

## Verified

WordPress 7.0.3 / PHP 8.5.3. The admin screens that previously logged two 404s now load with none, and the full admin sweep passes with 0 fatals and 0 console errors.